### PR TITLE
Ensure kernelspec dirs can be shared by providers

### DIFF
--- a/remote_kernel_provider/tests/test_provider.py
+++ b/remote_kernel_provider/tests/test_provider.py
@@ -13,23 +13,29 @@ from ..manager import RemoteKernelManager
 from ..lifecycle_manager import RemoteKernelLifecycleManager
 
 
-sample_kernel_json = {'argv': ['cat', '{kernel_id}', '{response_address}'],
-                      'display_name': 'Test kernel', }
+sample_kernel_json = {'argv': ['cat', '{kernel_id}', '{response_address}'], 'display_name': 'Test kernel', }
 
-dummy_connection_info = {'stdin_port': 47557, 'ip': '172.16.18.82', 'control_port': 55288,
-                         'hb_port': 55562, 'signature_scheme': 'hmac-sha256',
-                         'key': 'e75863c2-4a8a-49b0-b6d2-9e23837d5bd1', 'comm_port': 36458,
-                         'kernel_name': '', 'shell_port': 58031, 'transport': 'tcp', 'iopub_port': 52229}
+foo_kernel_json = {'argv': ['cat', '{kernel_id}', '{response_address}'], 'display_name': 'Test foo kernel', }
+
+bar_kernel_json = {'argv': ['cat', '{kernel_id}', '{response_address}'], 'display_name': 'Test bar kernel', }
+
+foo_connection_info = {'stdin_port': 47557, 'ip': '172.16.18.82', 'control_port': 55288,
+                       'hb_port': 55562, 'signature_scheme': 'hmac-sha256',
+                       'key': 'e75863c2-4a8a-49b0-b6d2-9e23837d5bd1', 'comm_port': 36458,
+                       'kernel_name': '', 'shell_port': 58031, 'transport': 'tcp', 'iopub_port': 52229}
 
 
-def install_sample_kernel(kernels_dir, kernel_name='sample', kernel_file='kernel.json'):
+def install_sample_kernel(kernels_dir,
+                          kernel_name='sample',
+                          kernel_file='kernel.json',
+                          json_content=sample_kernel_json):
+
     """install a sample kernel in a kernels directory"""
     sample_kernel_dir = pjoin(kernels_dir, kernel_name)
-    os.makedirs(sample_kernel_dir)
+    os.makedirs(sample_kernel_dir, exist_ok=True)
     json_file = pjoin(sample_kernel_dir, kernel_file)
     with open(json_file, 'w') as f:
-        json.dump(sample_kernel_json, f)
-    return sample_kernel_dir
+        json.dump(json_content, f)
 
 
 def is_uuid(uuid_to_test):
@@ -41,11 +47,11 @@ def is_uuid(uuid_to_test):
 
 
 def is_response_address(addr_to_test):
-    return re.match(r"[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\:[0-9]{4,5}$", addr_to_test) is not None
+    return re.match(r"[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}:[0-9]{4,5}$", addr_to_test) is not None
 
 
-class DummyKernelLifecycleManager(RemoteKernelLifecycleManager):
-    """A dummy kernel provider for testing KernelFinder"""
+class FooKernelLifecycleManager(RemoteKernelLifecycleManager):
+    """A fake kernel provider for testing KernelFinder"""
     connection_info = None
 
     def launch_process(self, kernel_cmd, **kwargs):
@@ -55,7 +61,7 @@ class DummyKernelLifecycleManager(RemoteKernelLifecycleManager):
         return self
 
     def confirm_remote_startup(self):
-        self.connection_info = dummy_connection_info
+        self.connection_info = foo_connection_info
         return True
 
     def shutdown_listener(self):
@@ -65,11 +71,22 @@ class DummyKernelLifecycleManager(RemoteKernelLifecycleManager):
         pass
 
 
-class DummyKernelProvider(RemoteKernelProviderBase):
-    """A dummy kernelspec provider subclass for testing"""
-    id = 'dummy'
-    kernel_file = 'dummy_kspec.json'
-    lifecycle_manager_classes = ['remote_kernel_provider.tests.test_provider.DummyKernelLifecycleManager']
+class BarKernelLifecycleManager(FooKernelLifecycleManager):
+    pass  # Full inheritance from FooKernelLifecycleManager
+
+
+class FooKernelProvider(RemoteKernelProviderBase):
+    """A fake kernelspec provider subclass for testing"""
+    id = 'foo'
+    kernel_file = 'foo_kspec.json'
+    lifecycle_manager_classes = ['remote_kernel_provider.tests.test_provider.FooKernelLifecycleManager']
+
+
+class BarKernelProvider(RemoteKernelProviderBase):
+    """A fake kernelspec provider subclass for testing"""
+    id = 'bar'
+    kernel_file = 'bar_kspec.json'
+    lifecycle_manager_classes = ['remote_kernel_provider.tests.test_provider.BarKernelLifecycleManager']
 
 
 class RemoteKernelProviderTests(unittest.TestCase):
@@ -77,35 +94,46 @@ class RemoteKernelProviderTests(unittest.TestCase):
     def setUp(self):
         self.env_patch = test_env()
         self.env_patch.start()
-        self.sample_kernel_dir = install_sample_kernel(
-            pjoin(paths.jupyter_data_dir(), 'kernels'))
-        self.prov_sample1_kernel_dir = install_sample_kernel(
-            pjoin(paths.jupyter_data_dir(), 'kernels'), 'dummy_kspec1', 'dummy_kspec.json')
-        self.prov_sample2_kernel_dir = install_sample_kernel(
-            pjoin(paths.jupyter_data_dir(), 'kernels'), 'dummy_kspec2', 'dummy_kspec.json')
+        install_sample_kernel(pjoin(paths.jupyter_data_dir(), 'kernels'))
+        install_sample_kernel(pjoin(paths.jupyter_data_dir(), 'kernels'),
+                              'foo_kspec', 'foo_kspec.json', foo_kernel_json)
+        install_sample_kernel(pjoin(paths.jupyter_data_dir(), 'kernels'),
+                              'foo_kspec2', 'foo_kspec.json', foo_kernel_json)
 
-        self.kernel_finder = discovery.KernelFinder(providers=[DummyKernelProvider()])
+        # This kspec overlaps with foo/foo_kspec.  Will be located as bar/foo_kspec
+        install_sample_kernel(pjoin(paths.jupyter_data_dir(), 'kernels'),
+                              'foo_kspec', 'bar_kspec.json', bar_kernel_json)
+
+        self.kernel_finder = discovery.KernelFinder(providers=[FooKernelProvider(),
+                                                               BarKernelProvider()])
 
     def tearDown(self):
         self.env_patch.stop()
 
     def test_find_remote_kernel_provider(self):
-        dummy_kspecs = list(self.kernel_finder.find_kernels())
-        assert len(dummy_kspecs) == 2
+        fake_kspecs = list(self.kernel_finder.find_kernels())
+        assert len(fake_kspecs) == 3
 
-        for name, spec in dummy_kspecs:
-            assert name.startswith('dummy/dummy_kspec')
-            assert spec['argv'] == sample_kernel_json['argv']
+        foo_kspecs = 0
+        for name, spec in fake_kspecs:
+            assert name.startswith('/foo_kspec', 3)
+            assert spec['argv'] == foo_kernel_json['argv']
+            if name.startswith('foo/'):
+                foo_kspecs += 1
+                assert spec['display_name'] == foo_kernel_json['display_name']
+            else:
+                assert spec['display_name'] == bar_kernel_json['display_name']
+        assert foo_kspecs == 2
 
     def test_launch_remote_kernel_provider(self):
-        conn_info, manager = self.kernel_finder.launch('dummy/dummy_kspec1')
+        conn_info, manager = self.kernel_finder.launch('foo/foo_kspec')
         assert isinstance(manager, RemoteKernelManager)
-        assert conn_info == dummy_connection_info
+        assert conn_info == foo_connection_info
         assert manager.kernel_id is not None
         assert is_uuid(manager.kernel_id)
 
         manager.kill()
         assert manager.lifecycle_manager is not None
-        assert isinstance(manager.lifecycle_manager, DummyKernelLifecycleManager)
+        assert isinstance(manager.lifecycle_manager, FooKernelLifecycleManager)
         manager.cleanup()
         assert manager.lifecycle_manager is None


### PR DESCRIPTION
Because different kernelspec providers use different `kernel.json` files, we can produce kernelspecs of the same names from different providers so long as referenced files (besides `kernel.json`) are also unique (where uniqueness is required).

This PR updates the test to ensure that isn't an issue.