### PR TITLE
Add kernel launchers in preparation for kernelspec tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# macos desktop services
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,17 @@
 language: python
+
 python:
     - 3.6
     - 3.5
     - 3.4
+
+cache:
+    directories:
+     - /home/travis/.sbt/
+
+before_install:
+    - mkdir -p $HOME/.sbt/launchers/1.2.1
+    - curl -L -o $HOME/.sbt/launchers/1.2.1/sbt-launch.jar http://central.maven.org/maven2/org/scala-sbt/sbt-launch/1.2.1/sbt-launch-1.2.1.jar
 
 install:
   - pip install --upgrade setuptools pip flake8 pytest-cov codecov
@@ -11,9 +20,8 @@ install:
   - pip freeze
 
 script:
-  - echo "SKIPPING TESTS UNTIL JUPYTER_KERNEL_MGMT HAS BEEN UPDATED"
-  # Skip tests until property jupyter_kernel_mgmt is available
-  # - py.test --cov remote_kernel_provider remote_kernel_provider
+  - echo "SKIPPING PROVIDER TESTS UNTIL JUPYTER_KERNEL_MGMT HAS BEEN UPDATED"
+  - make test
 
 after_success:
   - echo "Travis exited with ${TRAVIS_TEST_RESULT}"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,8 +3,13 @@ include HISTORY.rst
 include LICENSE
 include README.rst
 
-recursive-include tests *
+recursive-include remote_kernel_provider/tests *
+recursive-include remote_kernel_provider/kernel-launchers *
+
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
+recursive-exclude * .DS_Store
+recursive-exclude remote_kernel_provider/kernel-launchers/scala/toree-launcher *
+recursive-exclude remote_kernel_provider/kernel-launchers/bootstrap *
 
 recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -158,6 +158,3 @@ texinfo_documents = [
      'One line description of project.',
      'Miscellaneous'),
 ]
-
-
-

--- a/remote_kernel_provider/kernel-launchers/R/scripts/gateway_listener.py
+++ b/remote_kernel_provider/kernel-launchers/R/scripts/gateway_listener.py
@@ -1,0 +1,148 @@
+import os
+import tempfile
+import json
+import uuid
+import random
+import logging
+from socket import socket, timeout, AF_INET, SOCK_STREAM
+from ipython_genutils.py3compat import str_to_bytes
+from jupyter_client.connect import write_connection_file
+from threading import Thread
+
+max_port_range_retries = int(os.getenv('EG_MAX_PORT_RANGE_RETRIES', '5'))
+log_level = int(os.getenv('EG_LOG_LEVEL', '10'))
+
+logging.basicConfig(format='[%(levelname)1.1s %(asctime)s.%(msecs).03d %(name)s] %(message)s')
+
+logger = logging.getLogger('gateway_listener for R launcher')
+logger.setLevel(log_level)
+
+
+def _select_ports(count, lower_port, upper_port):
+    """Select and return n random ports that are available and adhere to the given port range, if applicable."""
+    ports = []
+    sockets = []
+    for i in range(count):
+        sock = _select_socket(lower_port, upper_port)
+        ports.append(sock.getsockname()[1])
+        sockets.append(sock)
+    for sock in sockets:
+        sock.close()
+    return ports
+
+
+def _select_socket(lower_port, upper_port):
+    """Create and return a socket whose port is available and adheres to the given port range, if applicable."""
+    sock = socket(AF_INET, SOCK_STREAM)
+    found_port = False
+    retries = 0
+    while not found_port:
+        try:
+            sock.bind(('0.0.0.0', _get_candidate_port(lower_port, upper_port)))
+            found_port = True
+        except Exception:
+            retries = retries + 1
+            if retries > max_port_range_retries:
+                raise RuntimeError(
+                    "Failed to locate port within range {}..{} after {} retries!".
+                    format(lower_port, upper_port, max_port_range_retries))
+    return sock
+
+
+def _get_candidate_port(lower_port, upper_port):
+    range_size = upper_port - lower_port
+    if range_size == 0:
+        return 0
+    return random.randint(lower_port, upper_port)
+
+
+def prepare_gateway_socket(lower_port, upper_port):
+    sock = _select_socket(lower_port, upper_port)
+    logger.info("Signal socket bound to host: {}, port: {}".format(sock.getsockname()[0], sock.getsockname()[1]))
+    sock.listen(1)
+    sock.settimeout(5)
+    return sock
+
+
+def get_gateway_request(sock):
+    conn = None
+    data = ''
+    request_info = None
+    try:
+        conn, addr = sock.accept()
+        while True:
+            buffer = conn.recv(1024).decode('utf-8')
+            if not buffer:  # send is complete
+                request_info = json.loads(data)
+                break
+            data = data + buffer  # append what we received until we get no more...
+    except Exception as e:
+        if type(e) is not timeout:
+            # fabricate shutdown.
+            logger.error("Listener encountered error '{}', shutting down...".format(e))
+            shutdown = dict()
+            shutdown['shutdown'] = 1
+            request_info = shutdown
+    finally:
+        if conn:
+            conn.close()
+
+    return request_info
+
+
+def gateway_listener(sock, parent_pid):
+    shutdown = False
+    while not shutdown:
+        request = get_gateway_request(sock)
+        if request:
+            signum = -1  # prevent logging poll requests since that occurs every 3 seconds
+            if request.get('signum') is not None:
+                signum = int(request.get('signum'))
+                os.kill(int(parent_pid), signum)
+            if request.get('shutdown') is not None:
+                shutdown = bool(request.get('shutdown'))
+            if signum != 0:
+                logger.debug("gateway_listener got request: {}".format(request))
+        else:  # check parent
+            try:
+                os.kill(int(parent_pid), 0)
+            except OSError:
+                shutdown = True
+                logger.info("Listener detected parent has been shutdown.")
+
+
+def setup_gateway_listener(fname, parent_pid, lower_port, upper_port):
+    ip = "0.0.0.0"
+    key = str_to_bytes(str(uuid.uuid4()))
+
+    gateway_socket = prepare_gateway_socket(lower_port, upper_port)
+
+    gateway_listener_thread = Thread(target=gateway_listener, args=(gateway_socket, parent_pid, ))
+    gateway_listener_thread.start()
+
+    basename = os.path.splitext(os.path.basename(fname))[0]
+    fd, conn_file = tempfile.mkstemp(suffix=".json", prefix=basename + "_")
+    os.close(fd)
+
+    ports = _select_ports(5, lower_port, upper_port)
+
+    conn_file, config = write_connection_file(fname=conn_file, ip=ip, key=key,
+                                              shell_port=ports[0], iopub_port=ports[1],
+                                              stdin_port=ports[2], hb_port=ports[3], control_port=ports[4])
+    try:
+        os.remove(conn_file)
+    except OSError:
+        pass
+
+    # Add in the gateway_socket and parent_pid fields...
+    config['comm_port'] = gateway_socket.getsockname()[1]
+    config['pid'] = parent_pid
+
+    with open(fname, 'w') as f:
+        f.write(json.dumps(config, indent=2))
+    return
+
+
+__all__ = [
+    'setup_gateway_listener',
+]

--- a/remote_kernel_provider/kernel-launchers/R/scripts/launch_IRkernel.R
+++ b/remote_kernel_provider/kernel-launchers/R/scripts/launch_IRkernel.R
@@ -1,0 +1,276 @@
+library(argparse)
+library(jsonlite)
+
+require("SparkR")
+require("base64enc")
+require("digest")
+require("stringr")
+
+r_libs_user <- Sys.getenv("R_LIBS_USER")
+
+sparkConfigList <- list(
+spark.executorEnv.R_LIBS_USER=r_libs_user,
+spark.rdd.compress="true")
+
+min_port_range_size = Sys.getenv("EG_MIN_PORT_RANGE_SIZE")
+if ( is.null(min_port_range_size) )
+    min_port_range_size = 1000
+
+# Initializes the Spark session/context and SQL context
+initialize_spark_session <- function(mode) {
+    # Make sure SparkR package is loaded last; this is necessary
+    # to avoid the need to fully qualify package namespace (using ::)
+    old <- getOption("defaultPackages")
+    options(defaultPackages = c(old, "SparkR"))
+
+    if (identical(mode, "eager")) {
+        # Start the spark context immediately if set to eager
+        spark <- SparkR::sparkR.session(enableHiveSupport = FALSE, sparkConfig=sparkConfigList)
+        assign("spark", spark, envir = .GlobalEnv)
+        sc <- SparkR:::callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", spark)
+        sqlContext <<- SparkR::sparkRSQL.init(sc)
+        assign("sc", sc, envir = .GlobalEnv)
+
+    } else {
+        # Keep lazy evaluation as default starting mode if initialization mode is lazy or not set at all
+        makeActiveBinding(".sparkRsession", sparkSessionFn, SparkR:::.sparkREnv)
+        makeActiveBinding(".sparkRjsc", sparkContextFn, SparkR:::.sparkREnv)
+
+        delayedAssign("spark", {get(".sparkRsession", envir=SparkR:::.sparkREnv)}, assign.env=.GlobalEnv)
+
+        # backward compatibility for Spark 1.6 and earlier notebooks
+        delayedAssign("sc", {get(".sparkRjsc", envir=SparkR:::.sparkREnv)}, assign.env=.GlobalEnv)
+        delayedAssign("sqlContext", {spark}, assign.env=.GlobalEnv)
+    }
+}
+
+sparkSessionFn <- local({
+     function(v) {
+       if (missing(v)) {
+         # get SparkSession
+
+         # create a new sparkSession
+         rm(".sparkRsession", envir=SparkR:::.sparkREnv) # rm to ensure no infinite recursion
+
+         get("sc", envir=.GlobalEnv)
+
+         sparkSession <- SparkR::sparkR.session(
+                                        sparkHome=Sys.getenv("SPARK_HOME"),
+                                        sparkConfig=sparkConfigList);
+         sparkSession
+       }
+     }
+   })
+
+sparkContextFn <- local({
+    function(v) {
+      if (missing(v)) {
+        # get SparkContext
+
+        # create a new sparkContext
+        rm(".sparkRjsc", envir=SparkR:::.sparkREnv) # rm to ensure no infinite recursion
+
+        message ("Obtaining Spark session...")
+
+        sparkContext <- SparkR:::sparkR.sparkContext(
+                                          sparkHome=Sys.getenv("SPARK_HOME"),
+                                          sparkEnvirMap=SparkR:::convertNamedListToEnv(sparkConfigList))
+
+        message ("Spark session obtained.")
+        sparkContext
+      }
+    }
+  })
+
+encrypt <- function(json, connection_file) {
+  # Ensure that the length of the data that will be encrypted is a
+  # multiple of 16 by padding with '%' on the right.
+  raw_payload <- str_pad(json, (str_length(json) %/% 16 + 1) * 16, side="right", pad="%")
+  message(paste("Raw Payload: ", raw_payload))
+
+  fn <- basename(connection_file)
+  tokens <- unlist(strsplit(fn, "kernel-"))
+  key <- charToRaw(substr(tokens[2], 1, 16))
+  # message(paste("AES Encryption Key: ", rawToChar(key)))
+
+  cipher <- AES(key, mode="ECB")
+  encrypted_payload <- cipher$encrypt(raw_payload)
+  encoded_payload = base64encode(encrypted_payload)
+  return(encoded_payload)
+}
+
+# Return connection information
+return_connection_info <- function(connection_file, response_addr){
+
+  response_parts <- strsplit(response_addr, ":")
+
+  if (length(response_parts[[1]])!=2){
+    cat("Invalid format for response address. Assuming pull mode...")
+    return(1)
+  }
+
+  response_ip <- response_parts[[1]][1]
+  response_port <- response_parts[[1]][2]
+
+  # Read in connection file to send back to JKG
+  con <- NULL
+  tryCatch(
+    {
+        con <- socketConnection(host=response_ip, port=response_port, blocking=FALSE, server=FALSE)
+        sendme <- read_json(connection_file)
+        # Add launcher process id to returned info...
+        sendme$pid <- Sys.getpid()
+        json <- jsonlite::toJSON(sendme, auto_unbox=TRUE)
+        message(paste("JSON Payload: ", json))
+
+        fn <- basename(connection_file)
+        if (!grepl("kernel-", fn)) {
+          message(paste("Invalid connection file name: ", connection_file))
+          return(NA)
+        }
+        payload <- encrypt(json, connection_file)
+        message(paste("Encrypted Payload: ", payload))
+        write_resp <- writeLines(payload, con)
+    },
+    error=function(cond) {
+        message(paste("Unable to connect to response address", response_addr ))
+        message("Here's the original error message:")
+        message(cond)
+        # Choose a return value in case of error
+        return(NA)
+    },
+    finally={
+        if (!is.null(con)) {
+            close(con)
+        }
+    }
+  )
+}
+
+# Figure out the connection_file to use
+determine_connection_file <- function(kernel_id){
+    base_file = paste("kernel-", kernel_id, sep="")
+    temp_file = tempfile(pattern=paste(base_file,"_",sep=""), fileext=".json")
+    cat(paste("Using connection file ",temp_file," \n",sep="'"))
+    return(temp_file)
+}
+
+validate_port_range <- function(port_range){
+    port_ranges = strsplit(port_range, "..", fixed=TRUE)
+    lower_port = as.integer(port_ranges[[1]][1])
+    upper_port = as.integer(port_ranges[[1]][2])
+
+    port_range_size = upper_port - lower_port
+    if (port_range_size != 0) {
+        if (port_range_size < min_port_range_size){
+            message(paste("Port range validation failed for range:", port_range, ". Range size must be at least",
+                min_port_range_size, "as specified by env EG_MIN_PORT_RANGE_SIZE"))
+            return(NA)
+        }
+    }
+    return(list("lower_port"=lower_port, "upper_port"=upper_port))
+}
+
+# Check arguments
+parser <- argparse::ArgumentParser(description="Parse Arguments for R Launcher")
+parser$add_argument("connection_file", nargs='?', help='Connection file to write connection info')
+parser$add_argument("--RemoteProcessProxy.kernel-id", nargs='?',
+       help="the id associated with the launched kernel")
+parser$add_argument("--RemoteProcessProxy.port-range", nargs='?', metavar='<lowerPort>..<upperPort>',
+       help="the range of ports impose for kernel ports")
+parser$add_argument("--RemoteProcessProxy.response-address", nargs='?', metavar='<ip>:<port>',
+      help="the IP:port address of the system hosting Enterprise Gateway and expecting response")
+parser$add_argument("--RemoteProcessProxy.spark-context-initialization-mode", nargs='?', default="none",
+      help="the initialization mode of the spark context: lazy, eager or none")
+parser$add_argument("--customAppName", nargs='?', help="the custom application name to be set")
+
+argv <- parser$parse_args()
+
+if (is.null(argv$connection_file) && is.null(argv$RemoteProcessProxy.kernel_id)){
+    message("At least one of the parameters: 'connection_file' or '--RemoteProcessProxy.kernel-id' must be provided!")
+    return(NA)
+}
+
+# if we have a response address, then deal with items relative to remote support (ports, gateway-socket, etc.)
+if (!is.null(argv$RemoteProcessProxy.response_address) && str_length(argv$RemoteProcessProxy.response_address) > 0){
+
+    #If port range argument is passed from kernel json with no value
+    if (is.null(argv$RemoteProcessProxy.port_range)){
+        argv$RemoteProcessProxy.port_range <- NA
+    }
+
+    #  If there is a response address, use pull socket mode
+    connection_file <- determine_connection_file(argv$RemoteProcessProxy.kernel_id)
+
+    # if port-range was provided, validate the range and determine bounds
+    lower_port = 0
+    upper_port = 0
+    if (!is.na(argv$RemoteProcessProxy.port_range)){
+        range <- validate_port_range(argv$RemoteProcessProxy.port_range)
+        if (length(range) > 1){
+            lower_port = range$lower_port
+            upper_port = range$upper_port
+        }
+    }
+
+    # Get the pid of the launcher so the listener thread (process) can detect its
+    # presence to know when to shutdown.
+    pid <- Sys.getpid()
+
+    # Hoop to jump through to get the directory this script resides in so that we can
+    # load the co-located python gateway_listener.py file.  This code will not work if
+    # called directly from within RStudio.
+    # https://stackoverflow.com/questions/1815606/rscript-determine-path-of-the-executing-script
+    launch_args <- commandArgs(trailingOnly = FALSE)
+    file_option <- "--file="
+    script_path <- sub(file_option, "", launch_args[grep(file_option, launch_args)])
+    listener_file <- paste(sep="/", dirname(script_path), "gateway_listener.py")
+
+    # Launch the gateway listener logic in an async manner and poll for the existence of
+    # the connection file before continuing.  Should there be an issue, Enterprise Gateway
+    # will terminate the launcher, so there's no need for a timeout.
+    python_cmd <- Sys.getenv("PYSPARK_PYTHON", "python")  # If present, use the same python specified for Spark
+
+    gw_listener_cmd <- stringr::str_interp(gsub("\n[:space:]*" , "",
+                paste(python_cmd,"-c \"import os, sys, imp;
+                gl = imp.load_source('setup_gateway_listener', '${listener_file}');
+                gl.setup_gateway_listener(fname='${connection_file}', parent_pid='${pid}', lower_port=${lower_port},
+                    upper_port=${upper_port})\"")))
+    system(gw_listener_cmd, wait=FALSE)
+
+    while (!file.exists(connection_file)) {
+        Sys.sleep(0.5)
+    }
+
+    return_connection_info(connection_file, argv$RemoteProcessProxy.response_address)
+} else {
+    # already provided
+    connection_file = argv$connection_file
+}
+
+# If spark context creation is desired go ahead and initialize the session/context
+# Otherwise, skip spark context creation if set to none or not provided
+if (!is.na(argv$RemoteProcessProxy.spark_context_initialization_mode)){
+    if (!identical(argv$RemoteProcessProxy.spark_context_initialization_mode, "none")){
+        # Add custom application name (spark.app.name) spark config if available, else default to kernel_id
+        if (!is.null(argv$customAppName) && str_length(argv$customAppName) > 0){
+            sparkConfigList[['spark.app.name']] <- argv$customAppName
+        } else {
+            sparkConfigList[['spark.app.name']] <- argv$RemoteProcessProxy.kernel_id
+        }
+        initialize_spark_session(argv$RemoteProcessProxy.spark_context_initialization_mode)
+    }
+}
+
+# Start the kernel
+IRkernel::main(connection_file)
+
+# Only unlink the connection file if we're launched for remote behavior.
+if (!is.na(argv$RemoteProcessProxy.response_address)){
+    unlink(connection_file)
+}
+
+# Stop the context and exit
+if (!identical(argv$RemoteProcessProxy.spark_context_initialization_mode, "none")){
+    sparkR.session.stop()
+}

--- a/remote_kernel_provider/kernel-launchers/bootstrap/bootstrap-kernel.sh
+++ b/remote_kernel_provider/kernel-launchers/bootstrap/bootstrap-kernel.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+KERNEL_LAUNCHERS_DIR=${KERNEL_LAUNCHERS_DIR:-/usr/local/bin/kernel-launchers}
+KERNEL_SPARK_CONTEXT_INIT_MODE=${KERNEL_SPARK_CONTEXT_INIT_MODE:-none}
+
+echo $0 env: `env`
+
+launch_python_kernel() {
+    # Launch the python kernel launcher - which embeds the IPython kernel and listens for interrupts
+    # and shutdown requests from Enterprise Gateway.
+
+    export JPY_PARENT_PID=$$  # Force reset of parent pid since we're detached
+
+	set -x
+	python ${KERNEL_LAUNCHERS_DIR}/python/scripts/launch_ipykernel.py --RemoteProcessProxy.kernel-id ${KERNEL_ID} --RemoteProcessProxy.response-address ${EG_RESPONSE_ADDRESS} --RemoteProcessProxy.spark-context-initialization-mode ${KERNEL_SPARK_CONTEXT_INIT_MODE}
+	{ set +x; } 2>/dev/null
+}
+
+launch_R_kernel() {
+    # Launch the R kernel launcher - which embeds the IRkernel kernel and listens for interrupts
+    # and shutdown requests from Enterprise Gateway.
+
+	set -x
+	Rscript ${KERNEL_LAUNCHERS_DIR}/R/scripts/launch_IRkernel.R --RemoteProcessProxy.kernel-id ${KERNEL_ID} --RemoteProcessProxy.response-address ${EG_RESPONSE_ADDRESS} --RemoteProcessProxy.spark-context-initialization-mode ${KERNEL_SPARK_CONTEXT_INIT_MODE}
+	{ set +x; } 2>/dev/null
+}
+
+launch_scala_kernel() {
+    # Launch the scala kernel launcher - which embeds the Apache Toree kernel and listens for interrupts
+    # and shutdown requests from Enterprise Gateway.  This kernel is currenly always launched using
+    # spark-submit, so additional setup is required.
+
+    PROG_HOME=${KERNEL_LAUNCHERS_DIR}/scala
+    KERNEL_ASSEMBLY=`(cd "${PROG_HOME}/lib"; ls -1 toree-assembly-*.jar;)`
+    TOREE_ASSEMBLY="${PROG_HOME}/lib/${KERNEL_ASSEMBLY}"
+    if [ ! -f ${TOREE_ASSEMBLY} ]; then
+        echo "Toree assembly '${PROG_HOME}/lib/toree-assembly-*.jar' is missing.  Exiting..."
+        exit 1
+    fi
+
+    # Toree launcher jar path, plus required lib jars (toree-assembly)
+    JARS="${TOREE_ASSEMBLY}"
+    # Toree launcher app path
+    LAUNCHER_JAR=`(cd "${PROG_HOME}/lib"; ls -1 toree-launcher*.jar;)`
+    LAUNCHER_APP="${PROG_HOME}/lib/${LAUNCHER_JAR}"
+    if [ ! -f ${LAUNCHER_APP} ]; then
+        echo "Scala launcher jar '${PROG_HOME}/lib/toree-launcher*.jar' is missing.  Exiting..."
+        exit 1
+    fi
+
+    SPARK_OPTS="--name ${KERNEL_USERNAME}-${KERNEL_ID}"
+    TOREE_OPTS="--alternate-sigint USR2"
+
+    set -x
+    eval exec \
+         "${SPARK_HOME}/bin/spark-submit" \
+         "${SPARK_OPTS}" \
+         --jars "${JARS}" \
+         --class launcher.ToreeLauncher \
+         "${LAUNCHER_APP}" \
+         "${TOREE_OPTS}" \
+         "--RemoteProcessProxy.kernel-id ${KERNEL_ID} --RemoteProcessProxy.response-address ${EG_RESPONSE_ADDRESS} --RemoteProcessProxy.spark-context-initialization-mode ${KERNEL_SPARK_CONTEXT_INIT_MODE}"
+    { set +x; } 2>/dev/null
+}
+
+# Ensure that required envs are present, check language before the dynamic values
+if [ -z "${KERNEL_LANGUAGE+x}" ]
+then
+    echo "KERNEL_LANGUAGE is required.  Set this value in the image or when starting container." 
+    exit 1
+fi
+if [ -z "${KERNEL_ID+x}" ] || [ -z "${EG_RESPONSE_ADDRESS+x}" ]
+then
+    echo "Both environment variables, KERNEL_ID and EG_RESPONSE_ADDRESS, are required.  Ensure this container is started by Enterprise Gateway."
+    exit 1
+fi
+
+# Invoke appropriate launcher based on KERNEL_LANGUAGE (case-insensitive)
+
+if [[ "${KERNEL_LANGUAGE,,}" == "python" ]]
+then
+    launch_python_kernel
+elif [[ "${KERNEL_LANGUAGE,,}" == "scala" ]]
+then
+    launch_scala_kernel
+elif [[ "${KERNEL_LANGUAGE,,}" == "r" ]]
+then
+    launch_R_kernel
+else
+	echo "Unrecognized value for KERNEL_LANGUAGE: '${KERNEL_LANGUAGE}'!"
+	exit 1
+fi
+exit 0
+

--- a/remote_kernel_provider/kernel-launchers/docker/scripts/launch_docker.py
+++ b/remote_kernel_provider/kernel-launchers/docker/scripts/launch_docker.py
@@ -1,0 +1,114 @@
+import os
+import sys
+import argparse
+from docker.client import DockerClient
+from docker.types import EndpointSpec, RestartPolicy
+import urllib3
+
+urllib3.disable_warnings()
+
+# Set env to False if the container should be left around for debug purposes, etc.
+remove_container = bool(os.getenv('EG_REMOVE_CONTAINER', 'True').lower() == 'true')
+swarm_mode = bool(os.getenv('EG_DOCKER_MODE', 'swarm').lower() == 'swarm')
+
+
+def launch_docker_kernel(kernel_id, response_addr, spark_context_init_mode):
+    # Launches a containerized kernel.
+
+    # Can't proceed if no image was specified.
+    image_name = os.environ.get('KERNEL_IMAGE', None)
+    if image_name is None:
+        sys.exit("ERROR - KERNEL_IMAGE not found in environment - kernel launch terminating!")
+
+    # Container name is composed of KERNEL_USERNAME and KERNEL_ID
+    container_name = os.environ.get('KERNEL_USERNAME', '') + '-' + kernel_id
+
+    # Determine network. If EG_DOCKER_NETWORK has not been propagated, fall back to 'bridge'...
+    docker_network = os.environ.get('EG_DOCKER_NETWORK', 'bridge')
+
+    # Build labels - these will be modelled similar to kubernetes: kernel_id, component, app, ...
+    labels = dict()
+    labels['kernel_id'] = kernel_id
+    labels['component'] = 'kernel'
+    labels['app'] = 'enterprise-gateway'
+
+    # Capture env parameters...
+    param_env = dict()
+    param_env['EG_RESPONSE_ADDRESS'] = response_addr
+    param_env['KERNEL_SPARK_CONTEXT_INIT_MODE'] = spark_context_init_mode
+
+    # Since the environment is specific to the kernel (per env stanza of kernelspec, KERNEL_ and ENV_WHITELIST)
+    # just add the env here.
+    param_env.update(os.environ)
+    param_env.pop('PATH')  # Let the image PATH be used.  Since this is relative to images, we're probably safe.
+
+    user = param_env.get('KERNEL_UID')
+    group = param_env.get('KERNEL_GID')
+
+    # setup common args
+    kwargs = dict()
+    kwargs['name'] = container_name
+    kwargs['user'] = user
+    kwargs['labels'] = labels
+
+    client = DockerClient.from_env()
+    if swarm_mode:
+        networks = list()
+        networks.append(docker_network)
+        mounts = list()
+        mounts.append("/usr/local/share/jupyter/kernels:/usr/local/share/jupyter/kernels:ro")
+        endpoint_spec = EndpointSpec(mode='dnsrr')
+        restart_policy = RestartPolicy(condition='none')
+
+        # finish args setup
+        kwargs['env'] = param_env
+        kwargs['endpoint_spec'] = endpoint_spec
+        kwargs['restart_policy'] = restart_policy
+        kwargs['container_labels'] = labels
+        kwargs['networks'] = networks
+        kwargs['groups'] = [group, '100']
+        if param_env.get('KERNEL_WORKING_DIR'):
+            kwargs['workdir'] = param_env.get('KERNEL_WORKING_DIR')
+        # kwargs['mounts'] = mounts   # Enable if necessary
+        # print("service args: {}".format(kwargs))  # useful for debug
+        client.services.create(image_name, **kwargs)
+    else:
+        # volumes = {'/usr/local/share/jupyter/kernels': {'bind': '/usr/local/share/jupyter/kernels', 'mode': 'ro'}}
+
+        # finish args setup
+        kwargs['hostname'] = container_name
+        kwargs['environment'] = param_env
+        kwargs['remove'] = remove_container
+        kwargs['network'] = docker_network
+        kwargs['group_add_list'] = [group, '100']
+        kwargs['detach'] = True
+        if param_env.get('KERNEL_WORKING_DIR'):
+            kwargs['working_dir'] = param_env.get('KERNEL_WORKING_DIR')
+        # kwargs['volumes'] = volumes   # Enable if necessary
+        # print("container args: {}".format(kwargs))  # useful for debug
+        client.containers.run(image_name, **kwargs)
+
+
+if __name__ == '__main__':
+    """
+        Usage: launch_docker_kernel
+                    [--RemoteProcessProxy.kernel-id <kernel_id>]
+                    [--RemoteProcessProxy.response-address <response_addr>]
+                    [--RemoteProcessProxy.spark-context-initialization-mode <mode>]
+    """
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--RemoteProcessProxy.kernel-id', dest='kernel_id', nargs='?',
+                        help='Indicates the id associated with the launched kernel.')
+    parser.add_argument('--RemoteProcessProxy.response-address', dest='response_address', nargs='?',
+                        metavar='<ip>:<port>', help='Connection address (<ip>:<port>) for returning connection file')
+    parser.add_argument('--RemoteProcessProxy.spark-context-initialization-mode', dest='spark_context_init_mode',
+                        nargs='?', help='Indicates whether or how a spark context should be created',
+                        default='none')
+
+    arguments = vars(parser.parse_args())
+    kernel_id = arguments['kernel_id']
+    response_addr = arguments['response_address']
+    spark_context_init_mode = arguments['spark_context_init_mode']
+
+    launch_docker_kernel(kernel_id, response_addr, spark_context_init_mode)

--- a/remote_kernel_provider/kernel-launchers/kubernetes/scripts/kernel-pod.yaml.j2
+++ b/remote_kernel_provider/kernel-launchers/kubernetes/scripts/kernel-pod.yaml.j2
@@ -1,0 +1,71 @@
+# This file defines the Kubernetes objects necessary for Enterprise Gateway kernels to run witihin Kubernetes.
+# Substitution parameters are processed by the launch_kubernetes.py code located in the
+# same directory.  Some values are factory values, while others (typically prefixed with 'kernel_') can be
+# provided by the client.
+#
+# This file can be customized as needed.  No changes are required to launch_kubernetes.py provided kernel_
+# values are used - which be automatically set from corresponding KERNEL_ env values.  Updates will be required
+# to launch_kubernetes.py if new document sections (i.e., new k8s 'kind' objects) are introduced.
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ kernel_pod_name }}"
+  namespace: "{{ kernel_namespace }}"
+  labels:
+    kernel_id: "{{ kernel_id }}"
+    app: enterprise-gateway
+    component: kernel
+spec:
+  restartPolicy: Never
+  serviceAccountName: "{{ kernel_service_account_name }}"
+# NOTE: that using runAsGroup requires that feature-gate RunAsGroup be enabled.
+# WARNING: Only using runAsUser w/o runAsGroup or NOT enabling the RunAsGroup feature-gate
+# will result in the new kernel pod's effective group of 0 (root)! although the user will
+# correspond to the runAsUser value.  As a result, BOTH should be uncommented AND the feature-gate
+# should be enabled to ensure expected behavior.  In addition, 'fsGroup: 100' is recommended so
+# that /home/jovyan can be written to via the 'users' group (gid: 100) irrespective of the
+# "kernel_uid" and "kernel_gid" values.
+  {% if kernel_uid is defined or kernel_gid is defined %}
+  securityContext:
+    {% if kernel_uid is defined %}
+    runAsUser: {{ kernel_uid | int }}
+    {% endif %}
+    {% if kernel_gid is defined %}
+    runAsGroup: {{ kernel_gid | int }}
+    {% endif %}
+    fsGroup: 100
+  {% endif %}
+  containers:
+  - env:
+    - name: EG_RESPONSE_ADDRESS
+      value: "{{ eg_response_address }}"
+    - name: KERNEL_LANGUAGE
+      value: "{{ kernel_language }}"
+    - name: KERNEL_SPARK_CONTEXT_INIT_MODE
+      value: "{{ kernel_spark_context_init_mode }}"
+    - name: KERNEL_NAME
+      value: "{{ kernel_name }}"
+    - name: KERNEL_USERNAME
+      value: "{{ kernel_username }}"
+    - name: KERNEL_ID
+      value: "{{ kernel_id }}"
+    - name: KERNEL_NAMESPACE
+      value: "{{ kernel_namespace }}"
+    image: "{{ kernel_image }}"
+    name: "{{ kernel_pod_name }}"
+    {% if kernel_working_dir is defined %}
+    workingDir: "{{ kernel_working_dir }}"
+    {% endif %}
+    {% if kernel_volume_mounts is defined %}
+    volumeMounts:
+      {% for volume_mount in kernel_volume_mounts %}
+    - {{ volume_mount }}
+      {% endfor %}
+    {% endif %}
+  {% if kernel_volumes is defined %}
+  volumes:
+    {% for volume in kernel_volumes %}
+  - {{ volume }}
+    {% endfor %}
+  {% endif %}

--- a/remote_kernel_provider/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
+++ b/remote_kernel_provider/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
@@ -1,0 +1,105 @@
+import os
+import sys
+import yaml
+import argparse
+from kubernetes import client, config
+import urllib3
+
+from jinja2 import FileSystemLoader, Environment
+
+urllib3.disable_warnings()
+
+KERNEL_POD_TEMPLATE_PATH = '/kernel-pod.yaml.j2'
+
+
+def generate_kernel_pod_yaml(keywords):
+    """Return the kubernetes pod spec as a yaml string.
+
+    - load jinja2 template from this file directory.
+    - substitute template variables with keywords items.
+    """
+    j_env = Environment(loader=FileSystemLoader(os.path.dirname(__file__)), trim_blocks=True, lstrip_blocks=True)
+    # jinja2 template substitutes template variables with None though keywords doesn't contain corresponding item.
+    # Therefore, no need to check if any are left unsubstituted; Kubernetes API server will validate the pod spec.
+    k8s_yaml = j_env.get_template(KERNEL_POD_TEMPLATE_PATH).render(**keywords)
+
+    return k8s_yaml
+
+
+def launch_kubernetes_kernel(kernel_id, response_addr, spark_context_init_mode):
+    # Launches a containerized kernel as a kubernetes pod.
+
+    config.load_incluster_config()
+
+    # Capture keywords and their values.
+    keywords = dict()
+
+    # Factory values...
+    # Since jupyter lower cases the kernel directory as the kernel-name, we need to capture its case-sensitive
+    # value since this is used to locate the kernel launch script within the image.
+    keywords['kernel_name'] = os.path.basename(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    keywords['kernel_id'] = kernel_id
+    keywords['eg_response_address'] = response_addr
+    keywords['kernel_spark_context_init_mode'] = spark_context_init_mode
+
+    # Walk env variables looking for names prefixed with KERNEL_.  When found, set corresponding keyword value
+    # with name in lower case.
+    for name, value in os.environ.items():
+        if name.startswith('KERNEL_'):
+            keywords[name.lower()] = yaml.safe_load(value)
+
+    # Substitute all template variable (wrapped with {{ }}) and generate `yaml` string.
+    k8s_yaml = generate_kernel_pod_yaml(keywords)
+
+    # For each k8s object (kind), call the appropriate API method.  Too bad there isn't a method
+    # that can take a set of objects.
+    #
+    # Creation for additional kinds of k8s objects can be added below.  Refer to
+    # https://github.com/kubernetes-client/python for API signatures.  Other examples can be found in
+    # https://github.com/jupyter-incubator/enterprise_gateway/blob/master/enterprise_gateway/services/processproxies/k8s.py
+    #
+    kernel_namespace = keywords['kernel_namespace']
+    k8s_objs = yaml.load_all(k8s_yaml)
+    for k8s_obj in k8s_objs:
+        if k8s_obj.get('kind'):
+            if k8s_obj['kind'] == 'Pod':
+                # print("{}".format(k8s_obj))  # useful for debug
+                client.CoreV1Api(client.ApiClient()).create_namespaced_pod(body=k8s_obj, namespace=kernel_namespace)
+            elif k8s_obj['kind'] == 'Secret':
+                client.CoreV1Api(client.ApiClient()).create_namespaced_secret(body=k8s_obj, namespace=kernel_namespace)
+            elif k8s_obj['kind'] == 'PersistentVolumeClaim':
+                client.CoreV1Api(client.ApiClient()).create_namespaced_persistent_volume_claim(
+                    body=k8s_obj, namespace=kernel_namespace)
+            elif k8s_obj['kind'] == 'PersistentVolume':
+                client.CoreV1Api(client.ApiClient()).create_persistent_volume(body=k8s_obj)
+            else:
+                sys.exit("ERROR - Unhandled Kubernetes object kind '{}' found in yaml file - "
+                         "kernel launch terminating!".format(k8s_obj['kind']))
+        else:
+            sys.exit("ERROR - Unknown Kubernetes object '{}' found in yaml file - kernel launch terminating!".
+                     format(k8s_obj))
+
+
+if __name__ == '__main__':
+    """
+        Usage: launch_kubernetes_kernel
+                    [--RemoteProcessProxy.kernel-id <kernel_id>]
+                    [--RemoteProcessProxy.response-address <response_addr>]
+                    [--RemoteProcessProxy.spark-context-initialization-mode <mode>]
+    """
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--RemoteProcessProxy.kernel-id', dest='kernel_id', nargs='?',
+                        help='Indicates the id associated with the launched kernel.')
+    parser.add_argument('--RemoteProcessProxy.response-address', dest='response_address', nargs='?',
+                        metavar='<ip>:<port>', help='Connection address (<ip>:<port>) for returning connection file')
+    parser.add_argument('--RemoteProcessProxy.spark-context-initialization-mode', dest='spark_context_init_mode',
+                        nargs='?', help='Indicates whether or how a spark context should be created',
+                        default='none')
+
+    arguments = vars(parser.parse_args())
+    kernel_id = arguments['kernel_id']
+    response_addr = arguments['response_address']
+    spark_context_init_mode = arguments['spark_context_init_mode']
+
+    launch_kubernetes_kernel(kernel_id, response_addr, spark_context_init_mode)

--- a/remote_kernel_provider/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/remote_kernel_provider/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -1,0 +1,389 @@
+import argparse
+import base64
+import json
+import logging
+import os
+import socket
+import tempfile
+import uuid
+from multiprocessing import Process
+from random import random
+from threading import Thread
+
+from Crypto.Cipher import AES
+from ipython_genutils.py3compat import str_to_bytes
+from jupyter_client.connect import write_connection_file
+
+
+# Minimum port range size and max retries
+min_port_range_size = int(os.getenv('EG_MIN_PORT_RANGE_SIZE', '1000'))
+max_port_range_retries = int(os.getenv('EG_MAX_PORT_RANGE_RETRIES', '5'))
+log_level = int(os.getenv('EG_LOG_LEVEL', '10'))
+
+logging.basicConfig(format='[%(levelname)1.1s %(asctime)s.%(msecs).03d %(name)s] %(message)s')
+
+logger = logging.getLogger('launch_ipykernel')
+logger.setLevel(log_level)
+
+
+def initialize_namespace(namespace, cluster_type='spark'):
+    """Initialize the kernel namespace.
+
+    Parameters
+    ----------
+    cluster_type : {'spark', 'dask', 'none'}
+        The cluster type to initialize. ``'none'`` results in no variables in
+        the initial namespace.
+    """
+    if cluster_type == 'spark':
+        try:
+            from pyspark.sql import SparkSession
+        except ImportError:
+            logger.info("A spark context was desired but the pyspark distribution is not present.  "
+                        "Spark context creation will not occur.")
+            return {}
+
+        def initialize_spark_session():
+            import atexit
+
+            """Initialize Spark session and replace global variable
+            placeholders with real Spark session object references."""
+            spark = SparkSession.builder.getOrCreate()
+            sc = spark.sparkContext
+            sql = spark.sql
+            sqlContext = spark._wrapped
+            sqlCtx = sqlContext
+
+            # Stop the spark session on exit
+            atexit.register(lambda: spark.stop())
+
+            namespace.update({'spark': spark,
+                              'sc': sc,
+                              'sql': sql,
+                              'sqlContext': sqlContext,
+                              'sqlCtx': sqlCtx})
+
+        init_thread = Thread(target=initialize_spark_session)
+        spark = WaitingForSparkSessionToBeInitialized('spark', init_thread, namespace)
+        sc = WaitingForSparkSessionToBeInitialized('sc', init_thread, namespace)
+        sqlContext = WaitingForSparkSessionToBeInitialized('sqlContext', init_thread, namespace)
+
+        def sql(query):
+            """Placeholder function. When called will wait for Spark session to be
+            initialized and call ``spark.sql(query)``"""
+            return spark.sql(query)
+
+        namespace.update({'spark': spark, 'sc': sc, 'sql': sql, 'sqlContext': sqlContext, 'sqlCtx': sqlContext})
+
+        init_thread.start()
+
+    elif cluster_type == 'dask':
+        import dask_yarn
+        cluster = dask_yarn.YarnCluster.from_current()
+        namespace.update({'cluster': cluster})
+    elif cluster_type != 'none':
+        raise RuntimeError("Unknown cluster_type: %r" % cluster_type)
+
+
+class WaitingForSparkSessionToBeInitialized(object):
+    """Wrapper object for SparkContext and other Spark session variables while the real Spark session is being
+    initialized in a background thread. The class name is intentionally worded verbosely explicit as it will show up
+    when executing a cell that contains only a Spark session variable like ``sc`` or ``sqlContext``.
+    """
+
+    # private and public attributes that show up for tab completion,
+    # to indicate pending initialization of Spark session
+    _WAITING_FOR_SPARK_SESSION_TO_BE_INITIALIZED = 'Spark Session not yet initialized ...'
+    WAITING_FOR_SPARK_SESSION_TO_BE_INITIALIZED = 'Spark Session not yet initialized ...'
+
+    # the same wrapper class is used for all Spark session variables, so we need to record the name of the variable
+    def __init__(self, global_variable_name, init_thread, namespace):
+        self._spark_session_variable = global_variable_name
+        self._init_thread = init_thread
+        self._namespace = namespace
+
+    # we intercept all method and attribute references on our temporary Spark session variable,
+    # wait for the thread to complete initializing the Spark sessions and then we forward the
+    # call to the real Spark objects
+    def __getattr__(self, name):
+        # ignore tab-completion request for __members__ or __methods__ and ignore meta property requests
+        if name.startswith("__"):
+            pass
+        elif name.startswith("_ipython_"):
+            pass
+        elif name.startswith("_repr_"):
+            pass
+        else:
+            # wait on thread to initialize the Spark session variables in global variable scope
+            self._init_thread.join(timeout=None)
+            # now return attribute/function reference from actual Spark object
+            return getattr(self._namespace[self._spark_session_variable], name)
+
+
+def prepare_gateway_socket(lower_port, upper_port):
+    sock = _select_socket(lower_port, upper_port)
+    logger.info("Signal socket bound to host: {}, port: {}".format(sock.getsockname()[0], sock.getsockname()[1]))
+    sock.listen(1)
+    sock.settimeout(5)
+    return sock
+
+
+def _encrypt(connection_info, conn_file):
+    # Block size for cipher obj can be 16, 24, or 32. 16 matches 128 bit.
+    BLOCK_SIZE = 16
+
+    # Ensure that the length of the data that will be encrypted is a
+    # multiple of BLOCK_SIZE by padding with '%' on the right.
+    PADDING = '%'
+    pad = lambda s: s.decode("utf-8") + (BLOCK_SIZE - len(s) % BLOCK_SIZE) * PADDING
+
+    # Encrypt connection_info whose length is a multiple of BLOCK_SIZE using
+    # AES cipher and then encode the resulting byte array using Base64.
+    encryptAES = lambda c, s: base64.b64encode(c.encrypt(pad(s)))
+
+    # Create a key using first 16 chars of the kernel-id that is burnt in
+    # the name of the connection file.
+    bn = os.path.basename(conn_file)
+    if (bn.find("kernel-") == -1):
+        logger.error("Invalid connection file name '{}'".format(conn_file))
+        raise RuntimeError("Invalid connection file name '{}'".format(conn_file))
+
+    tokens = bn.split("kernel-")
+    kernel_id = tokens[1]
+    key = kernel_id[0:16]
+    # print("AES Encryption Key '{}'".format(key))
+
+    # Creates the cipher obj using the key.
+    cipher = AES.new(key)
+
+    payload = encryptAES(cipher, connection_info)
+    return payload
+
+
+def return_connection_info(connection_file, response_addr, lower_port, upper_port):
+    response_parts = response_addr.split(":")
+    if len(response_parts) != 2:
+        logger.error("Invalid format for response address '{}'. "
+                     "Assuming 'pull' mode...".format(response_addr))
+        return
+
+    response_ip = response_parts[0]
+    try:
+        response_port = int(response_parts[1])
+    except ValueError:
+        logger.error("Invalid port component found in response address '{}'. "
+                     "Assuming 'pull' mode...".format(response_addr))
+        return
+
+    with open(connection_file) as fp:
+        cf_json = json.load(fp)
+        fp.close()
+
+    # add process and process group ids into connection info
+    pid = os.getpid()
+    cf_json['pid'] = str(pid)
+    cf_json['pgid'] = str(os.getpgid(pid))
+
+    # prepare socket address for handling signals
+    gateway_sock = prepare_gateway_socket(lower_port, upper_port)
+    cf_json['comm_port'] = gateway_sock.getsockname()[1]
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.connect((response_ip, response_port))
+        json_content = json.dumps(cf_json).encode(encoding='utf-8')
+        logger.debug("JSON Payload '{}".format(json_content))
+        payload = _encrypt(json_content, connection_file)
+        logger.debug("Encrypted Payload '{}".format(payload))
+        s.send(payload)
+    finally:
+        s.close()
+
+    return gateway_sock
+
+
+def determine_connection_file(conn_file, kid):
+    # If the directory exists, use the original file, else create a temporary file.
+    if conn_file is None or not os.path.exists(os.path.dirname(conn_file)):
+        if kid is not None:
+            basename = 'kernel-' + kid
+        else:
+            basename = os.path.splitext(os.path.basename(conn_file))[0]
+        fd, conn_file = tempfile.mkstemp(suffix=".json", prefix=basename + "_")
+        os.close(fd)
+        logger.debug("Using connection file '{}'.".format(conn_file))
+
+    return conn_file
+
+
+def _select_ports(count, lower_port, upper_port):
+    """Select and return n random ports that are available and adhere to the given port range, if applicable."""
+    ports = []
+    sockets = []
+    for i in range(count):
+        sock = _select_socket(lower_port, upper_port)
+        ports.append(sock.getsockname()[1])
+        sockets.append(sock)
+    for sock in sockets:
+        sock.close()
+    return ports
+
+
+def _select_socket(lower_port, upper_port):
+    """Create and return a socket whose port is available and adheres to the given port range, if applicable."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    found_port = False
+    retries = 0
+    while not found_port:
+        try:
+            sock.bind(('0.0.0.0', _get_candidate_port(lower_port, upper_port)))
+            found_port = True
+        except Exception:
+            retries = retries + 1
+            if retries > max_port_range_retries:
+                raise RuntimeError(
+                    "Failed to locate port within range {}..{} after {} retries!".
+                    format(lower_port, upper_port, max_port_range_retries))
+    return sock
+
+
+def _get_candidate_port(lower_port, upper_port):
+    range_size = upper_port - lower_port
+    if range_size == 0:
+        return 0
+    return random.randint(lower_port, upper_port)
+
+
+def _validate_port_range(port_range):
+    # if no argument was provided, return a range of 0
+    if not port_range:
+        return 0, 0
+
+    try:
+        port_ranges = port_range.split("..")
+        lower_port = int(port_ranges[0])
+        upper_port = int(port_ranges[1])
+
+        port_range_size = upper_port - lower_port
+        if port_range_size != 0:
+            if port_range_size < min_port_range_size:
+                raise RuntimeError(
+                    "Port range validation failed for range: '{}'.  Range size must be at least {} as specified by"
+                    " env EG_MIN_PORT_RANGE_SIZE".format(port_range, min_port_range_size))
+    except ValueError as ve:
+        raise RuntimeError("Port range validation failed for range: '{}'.  Error was: {}".format(port_range, ve))
+    except IndexError as ie:
+        raise RuntimeError("Port range validation failed for range: '{}'.  Error was: {}".format(port_range, ie))
+
+    return lower_port, upper_port
+
+
+def get_gateway_request(sock):
+    conn = None
+    data = ''
+    request_info = None
+    try:
+        conn, addr = sock.accept()
+        while True:
+            buffer = conn.recv(1024).decode('utf-8')
+            if not buffer:  # send is complete
+                request_info = json.loads(data)
+                break
+            data = data + buffer  # append what we received until we get no more...
+    except Exception as e:
+        if type(e) is not socket.timeout:
+            raise e
+    finally:
+        if conn:
+            conn.close()
+
+    return request_info
+
+
+def gateway_listener(sock, parent_pid):
+    shutdown = False
+    while not shutdown:
+        request = get_gateway_request(sock)
+        if request:
+            signum = -1  # prevent logging poll requests since that occurs every 3 seconds
+            if request.get('signum') is not None:
+                signum = int(request.get('signum'))
+                os.kill(parent_pid, signum)
+            if request.get('shutdown') is not None:
+                shutdown = bool(request.get('shutdown'))
+            if signum != 0:
+                logger.info("gateway_listener got request: {}".format(request))
+
+
+def start_ipython(namespace, cluster_type="spark", **kwargs):
+    from IPython import embed_kernel
+
+    # create an initial list of variables to clear
+    # we do this without deleting to preserve the locals so that
+    # initialize_namespace isn't affected by this mutation
+    to_delete = [k for k in namespace if not k.startswith('__')]
+
+    # initialize the namespace with the proper variables
+    initialize_namespace(namespace, cluster_type=cluster_type)
+
+    # delete the extraneous variables
+    for k in to_delete:
+        del namespace[k]
+
+    # Start the kernel
+    embed_kernel(local_ns=namespace, **kwargs)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('connection_file', nargs='?', help='Connection file to write connection info')
+    parser.add_argument('--RemoteProcessProxy.response-address', dest='response_address', nargs='?',
+                        metavar='<ip>:<port>', help='Connection address (<ip>:<port>) for returning connection file')
+    parser.add_argument('--RemoteProcessProxy.kernel-id', dest='kernel_id', nargs='?',
+                        help='Indicates the id associated with the launched kernel.')
+    parser.add_argument('--RemoteProcessProxy.port-range', dest='port_range', nargs='?',
+                        metavar='<lowerPort>..<upperPort>', help='Port range to impose for kernel ports')
+    parser.add_argument('--RemoteProcessProxy.spark-context-initialization-mode', dest='init_mode', nargs='?',
+                        default='none', help='the initialization mode of the spark context: lazy, eager or none')
+    parser.add_argument('--RemoteProcessProxy.cluster-type', dest='cluster_type', nargs='?',
+                        default='spark', help='the kind of cluster to initialize: spark, dask, or none')
+
+    arguments = vars(parser.parse_args())
+    connection_file = arguments['connection_file']
+    response_addr = arguments['response_address']
+    kernel_id = arguments['kernel_id']
+    lower_port, upper_port = _validate_port_range(arguments['port_range'])
+    spark_init_mode = arguments['init_mode']
+    cluster_type = arguments['cluster_type']
+    ip = "0.0.0.0"
+
+    if connection_file is None and kernel_id is None:
+        raise RuntimeError("At least one of the parameters: 'connection_file' or "
+                           "'--RemoteProcessProxy.kernel-id' must be provided!")
+
+    # If the connection file doesn't exist, then create it.
+    if (connection_file and not os.path.isfile(connection_file)) or kernel_id is not None:
+        key = str_to_bytes(str(uuid.uuid4()))
+        connection_file = determine_connection_file(connection_file, kernel_id)
+
+        ports = _select_ports(5, lower_port, upper_port)
+
+        write_connection_file(fname=connection_file, ip=ip, key=key, shell_port=ports[0], iopub_port=ports[1],
+                              stdin_port=ports[2], hb_port=ports[3], control_port=ports[4])
+        if response_addr:
+            gateway_socket = return_connection_info(connection_file, response_addr, lower_port, upper_port)
+            if gateway_socket:  # socket in use, start gateway listener thread
+                gateway_listener_process = Process(target=gateway_listener, args=(gateway_socket, os.getpid(),))
+                gateway_listener_process.start()
+
+    # Initialize the kernel namespace for the given cluster type
+    if cluster_type == 'spark' and spark_init_mode == 'none':
+        cluster_type = 'none'
+
+    # launch the IPython kernel instance
+    start_ipython(locals(), cluster_type=cluster_type, connection_file=connection_file, ip=ip)
+
+    try:
+        os.remove(connection_file)
+    except Exception:
+        pass

--- a/remote_kernel_provider/kernel-launchers/scala/toree-launcher/build.sbt
+++ b/remote_kernel_provider/kernel-launchers/scala/toree-launcher/build.sbt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+name := "toree-launcher"
+
+version := sys.props.getOrElse("version", default = "1.0").replaceAll("dev[0-9]", "SNAPSHOT")
+
+scalaVersion := "2.11.12"
+
+resolvers += "Typesafe Repo" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Sonatype Repository" at "http://oss.sonatype.org/content/repositories/releases"
+
+val sparkVersion = "2.4.1"
+
+libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion % "provided"
+libraryDependencies += "com.typesafe.play" %% "play-json" % "2.3.10" // Apache v2
+libraryDependencies += "org.apache.toree" %% "toree-assembly" % "0.3.0-incubating" from "https://repository.apache.org/content/repositories/releases/org/apache/toree/toree-assembly/0.3.0-incubating/toree-assembly-0.3.0-incubating.jar"
+

--- a/remote_kernel_provider/kernel-launchers/scala/toree-launcher/project/build.properties
+++ b/remote_kernel_provider/kernel-launchers/scala/toree-launcher/project/build.properties
@@ -1,0 +1,5 @@
+#
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+#
+sbt.version = 1.2.1

--- a/remote_kernel_provider/kernel-launchers/scala/toree-launcher/project/plugins.sbt
+++ b/remote_kernel_provider/kernel-launchers/scala/toree-launcher/project/plugins.sbt
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+logLevel := Level.Warn
+
+/*
+ * Following plugins have a dependency on sbt v0.13
+ */
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")

--- a/remote_kernel_provider/kernel-launchers/scala/toree-launcher/project/project/build.properties
+++ b/remote_kernel_provider/kernel-launchers/scala/toree-launcher/project/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.0.3

--- a/remote_kernel_provider/kernel-launchers/scala/toree-launcher/project/scalastyle-config.xml
+++ b/remote_kernel_provider/kernel-launchers/scala/toree-launcher/project/scalastyle-config.xml
@@ -1,0 +1,208 @@
+<!--
+  Copyright (c) Jupyter Development Team.
+  Distributed under the terms of the Modified BSD License.
+-->
+
+<!--
+
+If you wish to turn off checking for a section of code, you can put a comment in the source
+before and after the section, with the following syntax:
+
+  // scalastyle:off
+  ...  // stuff that breaks the styles
+  // scalastyle:on
+
+You can also disable only one rule, by specifying its rule id, as specified in:
+  http://www.scalastyle.org/rules-0.7.0.html
+
+  // scalastyle:off no.finalize
+  override def finalize(): Unit = ...
+  // scalastyle:on no.finalize
+
+This file is divided into 3 sections:
+ (1) rules that we enforce.
+ (2) rules that we would like to enforce, but haven't cleaned up the codebase to turn on yet
+     (or we need to make the scalastyle rule more configurable).
+ (3) rules that we don't want to enforce.
+-->
+
+<scalastyle>
+ <name>Scalastyle standard configuration</name>
+
+ <!-- ================================================================================ -->
+ <!--                               rules we enforce                                   -->
+ <!-- ================================================================================ -->
+
+ <check level="error" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
+
+ <check level="error" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
+  <parameters>
+   <parameter name="header"><![CDATA[/*
+ * Copyright (c) Jupyter Development Team.
+ */]]></parameter>
+  </parameters>
+ </check>
+
+ <check level="error" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
+
+ <check level="error" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
+
+ <check level="error" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
+
+ <check level="error" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxLineLength"><![CDATA[100]]></parameter>
+   <parameter name="tabSize"><![CDATA[2]]></parameter>
+   <parameter name="ignoreImports">true</parameter>
+  </parameters>
+ </check>
+
+ <check level="error" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
+  <parameters><parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter></parameters>
+ </check>
+
+ <check level="error" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+  <parameters><parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter></parameters>
+ </check>
+
+ <check level="error" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
+  <parameters><parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter></parameters>
+ </check>
+
+ <check level="error" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
+  <parameters><parameter name="maxParameters"><![CDATA[10]]></parameter></parameters>
+ </check>
+
+ <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
+
+ <check level="error" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
+
+ <check level="error" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
+
+ <check level="error" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
+
+ <check level="error" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
+  <parameters>
+   <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
+   <parameter name="doubleLineAllowed"><![CDATA[true]]></parameter>
+  </parameters>
+ </check>
+
+ <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
+
+ <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
+
+ <check level="error" class="org.scalastyle.scalariform.NonASCIICharacterChecker" enabled="true"></check>
+
+ <check level="error" class="org.scalastyle.scalariform.SpaceAfterCommentStartChecker" enabled="true"></check>
+
+ <check level="error" class="org.scalastyle.scalariform.EnsureSingleSpaceBeforeTokenChecker" enabled="true">
+  <parameters>
+   <parameter name="tokens">ARROW, EQUALS, ELSE, TRY, CATCH, FINALLY, LARROW, RARROW</parameter>
+  </parameters>
+ </check>
+
+ <check level="error" class="org.scalastyle.scalariform.EnsureSingleSpaceAfterTokenChecker" enabled="true">
+  <parameters>
+   <parameter name="tokens">ARROW, EQUALS, COMMA, COLON, IF, ELSE, DO, WHILE, FOR, MATCH, TRY, CATCH, FINALLY, LARROW, RARROW</parameter>
+  </parameters>
+ </check>
+
+ <!-- ??? usually shouldn't be checked into the code base. -->
+ <check level="error" class="org.scalastyle.scalariform.NotImplementedErrorUsage" enabled="true"></check>
+
+ <!-- All printlns need to be wrapped in '// scalastyle:off/on println' -->
+ <check customId="println" level="error" class="org.scalastyle.scalariform.TokenChecker" enabled="true">
+  <parameters><parameter name="regex">^println$</parameter></parameters>
+  <customMessage><![CDATA[Are you sure you want to println? If yes, wrap the code block with
+      // scalastyle:off println
+      println(...)
+      // scalastyle:on println]]></customMessage>
+ </check>
+
+ <check customId="classforname" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+  <parameters><parameter name="regex">Class\.forName</parameter></parameters>
+  <customMessage><![CDATA[
+      Are you sure that you want to use Class.forName? In most cases, you should use Utils.classForName instead.
+      If you must use Class.forName, wrap the code block with
+      // scalastyle:off classforname
+      Class.forName(...)
+      // scalastyle:on classforname
+    ]]></customMessage>
+ </check>
+
+ <!-- ================================================================================ -->
+ <!--       rules we'd like to enforce, but haven't cleaned up the codebase yet        -->
+ <!-- ================================================================================ -->
+
+ <!-- We cannot turn the following two on, because it'd fail a lot of string interpolation use cases. -->
+ <!-- Ideally the following two rules should be configurable to rule out string interpolation. -->
+ <check level="error" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="false"></check>
+ <check level="error" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="false"></check>
+
+ <!-- This breaks symbolic method names so we don't turn it on. -->
+ <!-- Maybe we should update it to allow basic symbolic names, and then we are good to go. -->
+ <check level="error" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="false">
+  <parameters>
+   <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
+  </parameters>
+ </check>
+
+ <!-- Should turn this on, but we have a few places that need to be fixed first -->
+ <check level="error" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="false"></check>
+
+ <!-- ================================================================================ -->
+ <!--                               rules we don't want                                -->
+ <!-- ================================================================================ -->
+
+ <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="false">
+  <parameters><parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter></parameters>
+ </check>
+
+ <!-- We want the opposite of this: NewLineAtEofChecker -->
+ <check level="error" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+
+ <!-- This one complains about all kinds of random things. Disable. -->
+ <check level="error" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="false"></check>
+
+ <!-- We use return quite a bit for control flows and guards -->
+ <check level="error" class="org.scalastyle.scalariform.ReturnChecker" enabled="false"></check>
+
+ <!-- We use null a lot in low level code and to interface with 3rd party code -->
+ <check level="error" class="org.scalastyle.scalariform.NullChecker" enabled="false"></check>
+
+ <!-- Doesn't seem super big deal here ... -->
+ <check level="error" class="org.scalastyle.scalariform.NoCloneChecker" enabled="false"></check>
+
+ <!-- Doesn't seem super big deal here ... -->
+ <check level="error" class="org.scalastyle.file.FileLengthChecker" enabled="false">
+  <parameters><parameter name="maxFileLength">800></parameter></parameters>
+ </check>
+
+ <!-- Doesn't seem super big deal here ... -->
+ <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="false">
+  <parameters><parameter name="maxTypes">30</parameter></parameters>
+ </check>
+
+ <!-- Doesn't seem super big deal here ... -->
+ <check level="error" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="false">
+  <parameters><parameter name="maximum">10</parameter></parameters>
+ </check>
+
+ <!-- Doesn't seem super big deal here ... -->
+ <check level="error" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="false">
+  <parameters><parameter name="maxLength">50</parameter></parameters>
+ </check>
+
+ <!-- Not exactly feasible to enforce this right now. -->
+ <!-- It is also infrequent that somebody introduces a new class with a lot of methods. -->
+ <check level="error" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="false">
+  <parameters><parameter name="maxMethods"><![CDATA[30]]></parameter></parameters>
+ </check>
+
+ <!-- Doesn't seem super big deal here, and we have a lot of magic numbers ... -->
+ <check level="error" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="false">
+  <parameters><parameter name="ignore">-1,0,1,2,3</parameter></parameters>
+ </check>
+
+</scalastyle>

--- a/remote_kernel_provider/kernel-launchers/scala/toree-launcher/src/main/main.iml
+++ b/remote_kernel_provider/kernel-launchers/scala/toree-launcher/src/main/main.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/scala" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/remote_kernel_provider/kernel-launchers/scala/toree-launcher/src/main/scala/launcher/KernelProfile.scala
+++ b/remote_kernel_provider/kernel-launchers/scala/toree-launcher/src/main/scala/launcher/KernelProfile.scala
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+package launcher
+
+
+import java.util.UUID.randomUUID
+import play.api.libs.json._
+import scala.util.Random
+import launcher.utils.SocketUtils
+
+
+case class KernelProfile(hb_port : Int,
+                         control_port : Int,
+                         iopub_port : Int,
+                         stdin_port : Int,
+                         shell_port : Int,
+                         key : String,
+                         kernel_name : String,
+                         signature_scheme : String,
+                         transport : String,
+                         ip : String)
+
+object KernelProfile {
+
+  def newKey() : String = randomUUID.toString
+
+  def createJsonProfile(portLowerBound: Int = -1,
+                        portUpperBound: Int = -1) : String = {
+
+    implicit val writes = Json.writes[KernelProfile]
+
+    val newKernelProfile = new KernelProfile(
+      hb_port = SocketUtils.findPort(portLowerBound, portUpperBound),
+      control_port = SocketUtils.findPort(portLowerBound, portUpperBound),
+      iopub_port = SocketUtils.findPort(portLowerBound, portUpperBound),
+      stdin_port = SocketUtils.findPort(portLowerBound, portUpperBound),
+      shell_port = SocketUtils.findPort(portLowerBound, portUpperBound),
+      key = newKey(),
+      kernel_name = "Apache Toree Scala", transport = "tcp", ip = "0.0.0.0",
+      signature_scheme = "hmac-sha256"
+    )
+
+    Json.prettyPrint(Json.toJson(newKernelProfile))
+  }
+}

--- a/remote_kernel_provider/kernel-launchers/scala/toree-launcher/src/main/scala/launcher/ToreeLauncher.scala
+++ b/remote_kernel_provider/kernel-launchers/scala/toree-launcher/src/main/scala/launcher/ToreeLauncher.scala
@@ -1,0 +1,315 @@
+/**
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+package launcher
+
+import java.io.{BufferedWriter, File, FileWriter, PrintStream}
+import java.nio.file.{Files, Paths}
+import java.net.{InetAddress, ServerSocket, Socket}
+
+import org.apache.toree.Main
+import play.api.libs.json._
+import java.lang.management.ManagementFactory
+
+import scala.io.BufferedSource
+import scala.collection.mutable.ArrayBuffer
+
+import sun.misc.Signal
+
+import launcher.utils.{SecurityUtils, SocketUtils}
+
+import org.apache.toree.utils.LogLike
+
+
+object ToreeLauncher extends LogLike {
+
+  val minPortRangeSize = sys.env.getOrElse("EG_MIN_PORT_RANGE_SIZE", "1000").toInt
+  val kernelTempDir : String = "eg-kernel"
+  var profilePath : String = _
+  var kernelId : String = _
+  var portLowerBound : Int = -1
+  var portUpperBound : Int = -1
+  var responseAddress : String = _
+  var alternateSigint : String = _
+  var initMode : String = "lazy"
+  var toreeArgs = ArrayBuffer[String]()
+
+  private def pathExists(filePath : String) : Boolean =
+    if (filePath == null) false
+    else Files.exists(Paths.get(filePath))
+
+  private def writeToFile(outputPath : String, content : String): Unit = {
+    val file = new File(outputPath)
+    if(!pathExists(file.getParentFile.toString)) {
+      file.getParentFile.mkdirs // mkdir if not exists
+    }
+    val bw = new BufferedWriter(new FileWriter(file))
+    try{
+      bw.write(content)
+    } finally {
+      bw.close()
+    }
+  }
+
+  private def initPortRange(portRange: String): Unit = {
+      val ports = portRange.split("\\.\\.")
+
+      this.portLowerBound = ports(0).toInt
+      this.portUpperBound = ports(1).toInt
+
+      logger.info("Port Range: lower bound ( %s ) / upper bound ( %s )"
+        .format(this.portLowerBound, this.portUpperBound))
+
+      if (this.portLowerBound != this.portUpperBound) {  // Range of zero disables port restrictions
+         if (this.portLowerBound < 0 || this.portUpperBound < 0 ||
+            (this.portUpperBound - this.portLowerBound < minPortRangeSize)) {
+            logger.error("Invalid port range, use --port-range <LowerBound>..<UpperBound>, " +
+              "range must be >= EG_MIN_PORT_RANGE_SIZE ($minPortRangeSize)")
+            sys.exit(-1)
+         }
+      }
+  }
+
+  private def initArguments(args: Array[String]): Unit = {
+
+    logger.info("Toree launcher arguments (initial):")
+    args.foreach(logger.info(_))
+    logger.info("---------------------------")
+
+    // Walk the arguments, collecting launcher options along the way and buildup a
+    // new toree arguments list.  There's got to be a better way to do this.
+    var i = 0
+    while ( i < args.length ) {
+      var arg: String = args(i)
+      arg match {
+
+        // Profile is a straight pass-thru to toree
+        case "--profile" =>
+          i += 1
+          profilePath = args(i).trim
+          toreeArgs += arg
+          toreeArgs += profilePath
+
+        // Alternate sigint is a straight pass-thru to toree
+        case "--alternate-sigint" =>
+          i += 1
+          alternateSigint = args(i).trim
+          toreeArgs += arg
+          toreeArgs += alternateSigint
+
+        // Initialization mode requires massaging for toree
+        case "--RemoteProcessProxy.spark-context-initialization-mode" =>
+          i += 1
+          initMode = args(i).trim
+          initMode match {
+            case "none" =>
+              toreeArgs += "--nosparkcontext"
+            case _ =>
+              toreeArgs += "--spark-context-initialization-mode"
+              toreeArgs += initMode
+          }
+
+        // Port range doesn't apply to toree, consume here
+        case "--RemoteProcessProxy.port-range" =>
+          i += 1
+          initPortRange(args(i).trim)
+
+        // Response address doesn't apply to toree, consume here
+        case "--RemoteProcessProxy.response-address" =>
+          i += 1
+          responseAddress = args(i).trim
+
+        // kernel id doesn't apply to toree, consume here
+        case "--RemoteProcessProxy.kernel-id" =>
+          i += 1
+          kernelId = args(i).trim
+
+        // All other arguments should pass-thru to toree
+        case _ => toreeArgs += args(i).trim
+      }
+      i += 1
+    }
+  }
+
+  // Borrowed from toree to avoid dependency
+  private def deleteDirRecur(file: File): Unit = {
+    // delete directory recursively
+    if (file != null){
+      if (file.isDirectory){
+        file.listFiles.foreach(deleteDirRecur)
+      }
+      if (file.exists){
+        file.delete
+      }
+    }
+  }
+
+  private def determineConnectionFile(connectionFile: String, kernelId: String): String = {
+    // We know the connection file does not exist, so create a temporary directory
+    // and derive the filename from kernelId, if not null.
+    // If kernelId is null, then use the filename in the connectionFile.
+
+    val tmpPath = Files.createTempDirectory(kernelTempDir)
+    // tmpPath.toFile.deleteOnExit() doesn't appear to work, use system hook
+    sys.addShutdownHook{
+      deleteDirRecur(tmpPath.toFile)
+    }
+    val fileName = if (kernelId != null) "kernel-" + kernelId + ".json"
+      else Paths.get(connectionFile).getFileName.toString
+    val newPath = Paths.get(tmpPath.toString, fileName)
+    val newConnectionFile = newPath.toString
+    // Locate --profile and replace next element with new name.  If it doesn't exist, add both.
+    val profileIndex = toreeArgs.indexOf("--profile")
+    if (profileIndex >= 0) {
+      toreeArgs(profileIndex + 1) = newConnectionFile
+    } else {
+        toreeArgs += "--profile"
+        toreeArgs += newConnectionFile
+    }
+
+    newConnectionFile
+  }
+
+  private def getPID : String = {
+    // Return the current process ID. If not an integer string, gateway will ignore.
+    ManagementFactory.getRuntimeMXBean.getName.split('@')(0)
+  }
+
+  private def initProfile(args : Array[String]): ServerSocket = {
+
+    var gatewaySocket : ServerSocket = null
+
+    initArguments(args)
+
+    if (profilePath == null && kernelId == null){
+      logger.error("At least one of '--profile' or '--RemoteProcessProxy.kernel-id' " +
+        "must be provided - exiting!")
+      sys.exit(-1)
+    }
+
+    if (!pathExists(profilePath)) {
+      profilePath = determineConnectionFile(profilePath, kernelId)
+
+      logger.info("The profile %s doesn't exist, now creating it...".format(profilePath))
+
+      val content = KernelProfile.createJsonProfile(this.portLowerBound, this.portUpperBound)
+      writeToFile(profilePath, content)
+
+      if (pathExists(profilePath)) {
+        logger.info("%s saved".format(profilePath))
+      } else {
+        logger.error("Failed to create: %s".format(profilePath))
+        sys.exit(-1)
+      }
+
+      // Now need to also return the PID info in connection JSON
+      val connectionJson = Json.parse(content)
+
+      val pidJson = connectionJson.as[JsObject] ++ Json.obj("pid" -> getPID)
+
+      // Enterprise Gateway wants to establish socket communication. Create socket and
+      // convey port number back to gateway.
+      gatewaySocket = SocketUtils.findSocket(this.portLowerBound, this.portUpperBound)
+      val gsJson = pidJson ++ Json.obj("comm_port" -> gatewaySocket.getLocalPort)
+      val jsonContent = Json.toJson(gsJson).toString()
+
+      if (responseAddress != null){
+        logger.info("JSON Payload: '%s'".format(jsonContent))
+        val payload = SecurityUtils.encrypt(profilePath, jsonContent)
+        logger.info("Encrypted Payload: '%s'".format(payload))
+        SocketUtils.writeToSocket(responseAddress, payload)
+      }
+    }
+    gatewaySocket
+  }
+
+  private def getGatewayRequest(gatewaySocket : ServerSocket): String = {
+    val s = gatewaySocket.accept()
+    val data = new BufferedSource(s.getInputStream).getLines.mkString
+    s.close()
+    data
+  }
+
+  private def getReconciledSignalName(sigNum: Int): String = {
+    // To raise the signal, we must map the signal number back to the appropriate
+    // name as follows:  Take the common case and assume interrupt and check if an
+    // alternate interrupt signal has been given. If sigNum = 9, use "TERM", else
+    // if no alternate has been provided use "INT".  Note that use of SIGINT won't
+    // get received because the JVM won't propagate to background threads, buy it's
+    // the best we can do.  We'll still issue a warning in the log.
+
+    require(sigNum > 0, "sigNum must be greater than zero")
+
+    if (sigNum == 9) "TERM"
+    else {
+      if (alternateSigint == null) {
+        logger.warn("--alternate-sigint is not defined and signum %d has been " +
+                 "requested.  Using SIGINT, which probably won't get received due to JVM " +
+                 "preventing interrupts on background processes.  " +
+                 "Define --alternate-sigint using __TOREE_OPTS__."
+                   .format(sigNum))
+        "INT"
+      }
+      else alternateSigint
+    }
+  }
+
+  private def gatewayListener(gatewaySocket : ServerSocket): Unit = {
+    var stop = false
+    while (!stop) {
+      val requestData = getGatewayRequest(gatewaySocket)
+
+      // Handle each of the requests.  Note that we do not make an assumption that these are
+      // mutually exclusive - although that will probably be the case for now.  Over time,
+      // this should probably get refactored into a) better scala and b) token/classes for
+      // each request.
+
+      val requestJson = Json.parse(requestData).as[JsObject].value
+
+      // Signal the kernel...
+      if ( requestJson.contains("signum")) {
+        val sigNum = requestJson("signum").asInstanceOf[JsNumber].value.toInt
+        if ( sigNum > 0 ) {
+          // If sigNum anything but 0 (for poll), use Signal.raise(signal) to signal the kernel.
+          val sigName = getReconciledSignalName(sigNum)
+          val sigToRaise = new Signal(sigName)
+          logger.info("Gateway listener raising signal: '%s' (%d) for signum: %d".
+                   format(sigToRaise.getName, sigToRaise.getNumber, sigNum))
+          Signal.raise(sigToRaise)
+        }
+      }
+      // Stop the listener...
+      if ( requestJson.contains("shutdown")) {
+        val shutdown = requestJson("shutdown").asInstanceOf[JsNumber].value.toInt
+        if ( shutdown == 1 ) {
+          // Enterprise gateway has been instructed to shutdown the kernel, so let's stop
+          // the listener so that it doesn't interfere with poll() calls.
+          logger.info("Stopping gateway listener.")
+          stop = true
+        }
+      }
+    }
+  }
+
+  def main(args: Array[String]) {
+    val gatewaySocket = initProfile(args)
+
+    // if gatewaySocket is not null, start a thread to listen on socket
+    if ( gatewaySocket != null ){
+      val gatewayListenerThread = new Thread {
+        override def run() {
+          gatewayListener(gatewaySocket)
+        }
+      }
+      logger.info("Starting gateway listener...")
+      gatewayListenerThread.start()
+    }
+
+    logger.info("Toree kernel arguments (final):")
+    toreeArgs.foreach(logger.info(_))
+    logger.info("---------------------------")
+    Main.main(toreeArgs.toArray)
+  }
+}

--- a/remote_kernel_provider/kernel-launchers/scala/toree-launcher/src/main/scala/launcher/utils/SecurityUtils.scala
+++ b/remote_kernel_provider/kernel-launchers/scala/toree-launcher/src/main/scala/launcher/utils/SecurityUtils.scala
@@ -1,0 +1,60 @@
+/**
+  * Copyright (c) Jupyter Development Team.
+  * Distributed under the terms of the Modified BSD License.
+  */
+
+package launcher.utils
+
+import java.nio.charset.StandardCharsets
+import java.security.Key
+import java.util.Base64
+
+import javax.crypto.Cipher
+import javax.crypto.spec.SecretKeySpec
+
+import org.apache.toree.utils.LogLike
+
+object SecurityUtils extends LogLike {
+
+  def encrypt(profilePath: String, value: String): String = {
+    if (profilePath.indexOf("kernel-") == -1) {
+      logger.error("Invalid connection file name '%s', now exit.".format(profilePath)) // scalastyle:off
+      sys.exit(-1)
+    }
+
+    val clearText = getClearText(value)
+    val cipher: Cipher = Cipher.getInstance("AES")
+    val file = new java.io.File(profilePath)
+    val fileName = file.getName()
+    val tokens = fileName.split("kernel-")
+    val key = tokens(1).substring(0, 16)
+    val aesKey: Key = new SecretKeySpec(key.getBytes(StandardCharsets.UTF_8), "AES")
+
+    logger.info("Raw Payload: '%s'".format(clearText))
+    // logger.info("AES Key: '%s'".format(key))
+    cipher.init(Cipher.ENCRYPT_MODE, aesKey)
+    Base64.getEncoder.encodeToString(cipher.doFinal(clearText.getBytes(StandardCharsets.UTF_8)))
+  }
+
+  private def getClearText(value: String): String = {
+    val len = value.length()
+
+    if (len % 16 == 0) {
+      // If the length of the string is already a multiple of 16, then
+      // just return it.
+      value
+    }
+    else {
+      // Ensure that the length of the data that will be encrypted is a
+      // multiple of 16 by padding with '%' on the right.
+      //
+      // Note that the padding is not needed in Scala but Python and R
+      // need padding. In order to keep things consistent across all the
+      // languages(so that EG on the receiving end can behave the same
+      // way regardless of the language), we are also padding for Scala.
+      val targetLength = (len / 16 + 1) * 16
+      val clearText = value.padTo(targetLength, "%").mkString
+      clearText
+    }
+  }
+}

--- a/remote_kernel_provider/kernel-launchers/scala/toree-launcher/src/main/scala/launcher/utils/SocketUtils.scala
+++ b/remote_kernel_provider/kernel-launchers/scala/toree-launcher/src/main/scala/launcher/utils/SocketUtils.scala
@@ -1,0 +1,89 @@
+/**
+  * Copyright (c) Jupyter Development Team.
+  * Distributed under the terms of the Modified BSD License.
+  */
+
+package launcher.utils
+
+import java.io.PrintStream
+import java.net.{InetAddress, ServerSocket, Socket}
+
+import org.apache.toree.utils.LogLike
+
+import scala.util.Random
+
+
+object SocketUtils extends LogLike {
+
+  val random: Random = new Random (System.currentTimeMillis)
+
+  def writeToSocket(socketAddress : String, content : String): Unit = {
+    val ipPort = socketAddress.split(":")
+    if (ipPort.length == 2) {
+      logger.info("Sending connection info to gateway at %s\n%s".format(socketAddress, content)) // scalastyle:off
+      val ip = ipPort(0)
+      val port = ipPort(1).toInt
+      val s = new Socket(InetAddress.getByName(ip), port)
+      val out = new PrintStream(s.getOutputStream)
+      try {
+        out.append(content)
+        out.flush()
+      } finally {
+        s.close()
+      }
+    } else {
+      logger.error("Invalid format for response address '%s'!".format(socketAddress)) // scalastyle:off
+    }
+  }
+
+  def findPort(portLowerBound: Int, portUpperBound: Int): Int = {
+
+    val socket = findSocket(portLowerBound, portUpperBound)
+    val port = socket.getLocalPort
+    logger.info("port %s is available".format(port)) // scalastyle:off
+
+    // now Close the socket/port
+    socket.close()
+
+    logger.info("Port %s closed...".format(port)) // scalastyle:off
+
+    port
+  }
+
+  def findSocket(portLowerBound: Int, portUpperBound: Int): ServerSocket = {
+
+    var foundAvailable: Boolean = false
+    var socket: ServerSocket = null
+
+    while (foundAvailable == false) {
+
+      val candidatePort = getCandidatePort(portLowerBound, portUpperBound)
+
+      // try candidatePort - only display 'Trying...' if in range
+      if ( candidatePort > 0 )
+        logger.info("Trying port %s ...".format(candidatePort)) // scalastyle:off
+
+      try {
+        socket = new ServerSocket(candidatePort)
+        // return the socket to be used
+        foundAvailable = true
+      } catch {
+        case _ : Throwable => logger.info("port %s is in use".format(candidatePort)) // scalastyle:off
+        socket = null
+      }
+    }
+
+    socket
+  }
+
+  private def getCandidatePort(portLowerBound: Int, portUpperBound: Int): Int = {
+
+    val portRange = portUpperBound - portLowerBound
+    if ( portRange <= 0 )
+        return 0
+
+    val port = portLowerBound + random.nextInt(portRange)
+
+    port
+  }
+}

--- a/remote_kernel_provider/spec_utils.py
+++ b/remote_kernel_provider/spec_utils.py
@@ -1,0 +1,54 @@
+import shutil
+import tempfile
+
+from os import path
+from distutils import dir_util
+
+kernel_launchers_dir = path.join(path.dirname(__file__), 'kernel-launchers')
+
+
+def create_staging_directory(parent_dir=None):
+    """Creates a temporary staging directory at the specified location.
+       If no `parent_dir` is specified, the platform-specific "temp" directory is used.
+    """
+    return tempfile.mkdtemp(prefix="staging_", dir=parent_dir)
+
+
+def delete_staging_directory(dir_name):
+    """Deletes the specified staging directory."""
+    shutil.rmtree(dir_name)
+
+
+def copy_python_launcher(dir_name):
+    """Copies the Python launcher files to the specified directory."""
+
+    python_dir = path.join(kernel_launchers_dir, 'python')
+    dir_util.copy_tree(src=python_dir, dst=dir_name)
+
+
+def copy_r_launcher(dir_name):
+    """Copies the R launcher files to the specified directory."""
+
+    r_dir = path.join(kernel_launchers_dir, 'R')
+    dir_util.copy_tree(src=r_dir, dst=dir_name)
+
+
+def copy_scala_launcher(dir_name):
+    """Copies the Scala launcher files to the specified directory."""
+
+    scala_dir = path.join(kernel_launchers_dir, 'scala')
+    dir_util.copy_tree(src=scala_dir, dst=dir_name)
+
+
+def copy_kubernetes_launcher(dir_name):
+    """Copies the Kubernetes launcher files to the specified directory."""
+
+    k8s_dir = path.join(kernel_launchers_dir, 'kubernetes')
+    dir_util.copy_tree(src=k8s_dir, dst=dir_name)
+
+
+def copy_docker_launcher(dir_name):
+    """Copies the Docker launcher files to the specified directory."""
+
+    docker_dir = path.join(kernel_launchers_dir, 'docker')
+    dir_util.copy_tree(src=docker_dir, dst=dir_name)

--- a/remote_kernel_provider/tests/test_spec_utils.py
+++ b/remote_kernel_provider/tests/test_spec_utils.py
@@ -1,0 +1,158 @@
+from remote_kernel_provider import spec_utils
+
+from os import path
+import glob
+import pytest
+import shutil
+import tempfile
+
+temp_dir = None
+
+
+@pytest.fixture(scope='function')
+def create_temp_dir(request):
+    global temp_dir
+    temp_dir = tempfile.mkdtemp()
+
+    def delete_temp_dir():
+        shutil.rmtree(temp_dir)
+
+    request.addfinalizer(delete_temp_dir)
+
+
+def test_staging_directory(create_temp_dir):
+    # Create two staging dirs, one in the temp location, the other with no parent.
+    staging_dir = spec_utils.create_staging_directory(parent_dir=temp_dir)
+    assert path.isdir(staging_dir)
+    assert path.basename(staging_dir).startswith("staging_")
+
+    staging_dir2 = spec_utils.create_staging_directory()
+    assert path.isdir(staging_dir2)
+    assert path.basename(staging_dir2).startswith("staging_")
+
+    # Ensure the two directories differ
+    assert staging_dir != staging_dir2
+
+    # Remove the staging dirs
+    spec_utils.delete_staging_directory(staging_dir2)
+    assert not path.exists(staging_dir2)
+
+    spec_utils.delete_staging_directory(staging_dir)
+    assert not path.exists(staging_dir)
+    assert path.isdir(temp_dir)
+
+
+def test_copy_python_launcher(create_temp_dir):
+    kernel_name = 'python_kernel'
+
+    staging_dir = spec_utils.create_staging_directory(parent_dir=temp_dir)
+    spec_dir = path.join(staging_dir, kernel_name)
+
+    spec_utils.copy_python_launcher(spec_dir)
+
+    assert path.isdir(spec_dir)
+    scripts_dir = path.join(spec_dir, 'scripts')
+    assert path.isdir(scripts_dir)
+    launcher_file = path.join(spec_dir, 'scripts', 'launch_ipykernel.py')
+    assert path.isfile(launcher_file)
+
+    spec_utils.delete_staging_directory(staging_dir)
+    assert not path.exists(launcher_file)
+    assert not path.exists(scripts_dir)
+    assert not path.exists(spec_dir)
+
+
+def test_copy_r_launcher(create_temp_dir):
+    kernel_name = 'r_kernel'
+
+    staging_dir = spec_utils.create_staging_directory(parent_dir=temp_dir)
+    spec_dir = path.join(staging_dir, kernel_name)
+
+    spec_utils.copy_r_launcher(spec_dir)
+
+    assert path.isdir(spec_dir)
+    scripts_dir = path.join(spec_dir, 'scripts')
+    assert path.isdir(scripts_dir)
+    launcher_file = path.join(spec_dir, 'scripts', 'launch_IRkernel.R')
+    assert path.isfile(launcher_file)
+    gateway_file = path.join(spec_dir, 'scripts', 'gateway_listener.py')
+    assert path.isfile(gateway_file)
+
+    spec_utils.delete_staging_directory(staging_dir)
+    assert not path.exists(gateway_file)
+    assert not path.exists(launcher_file)
+    assert not path.exists(scripts_dir)
+    assert not path.exists(spec_dir)
+
+
+def test_copy_scala_launcher(create_temp_dir):
+    kernel_name = 'scala_kernel'
+
+    staging_dir = spec_utils.create_staging_directory(parent_dir=temp_dir)
+    spec_dir = path.join(staging_dir, kernel_name)
+
+    spec_utils.copy_scala_launcher(spec_dir)
+
+    assert path.isdir(spec_dir)
+    lib_dir = path.join(spec_dir, 'lib')
+    assert path.isdir(lib_dir)
+    launcher_file = path.join(spec_dir, 'lib', 'toree-launcher_*')
+    matches = glob.glob(launcher_file)
+    assert len(matches) == 1
+    launcher_file = matches[0]
+    assert path.isfile(launcher_file)
+
+    toree_jar = path.join(spec_dir, 'lib', 'toree-assembly-*')
+    matches = glob.glob(toree_jar)
+    assert len(matches) == 1
+    toree_jar = matches[0]
+    assert path.isfile(toree_jar)
+
+    spec_utils.delete_staging_directory(staging_dir)
+    assert not path.exists(toree_jar)
+    assert not path.exists(launcher_file)
+    assert not path.exists(lib_dir)
+    assert not path.exists(spec_dir)
+
+
+def test_copy_kubernetes_launcher(create_temp_dir):
+    kernel_name = 'k8s_kernel'
+
+    staging_dir = spec_utils.create_staging_directory(parent_dir=temp_dir)
+    spec_dir = path.join(staging_dir, kernel_name)
+
+    spec_utils.copy_kubernetes_launcher(spec_dir)
+
+    assert path.isdir(spec_dir)
+    scripts_dir = path.join(spec_dir, 'scripts')
+    assert path.isdir(scripts_dir)
+    launcher_file = path.join(spec_dir, 'scripts', 'launch_kubernetes.py')
+    assert path.isfile(launcher_file)
+    pod_template = path.join(spec_dir, 'scripts', 'kernel-pod.yaml.j2')
+    assert path.isfile(pod_template)
+
+    spec_utils.delete_staging_directory(staging_dir)
+    assert not path.exists(pod_template)
+    assert not path.exists(launcher_file)
+    assert not path.exists(scripts_dir)
+    assert not path.exists(spec_dir)
+
+
+def test_copy_docker_launcher(create_temp_dir):
+    kernel_name = 'docker_kernel'
+
+    staging_dir = spec_utils.create_staging_directory(parent_dir=temp_dir)
+    spec_dir = path.join(staging_dir, kernel_name)
+
+    spec_utils.copy_docker_launcher(spec_dir)
+
+    assert path.isdir(spec_dir)
+    scripts_dir = path.join(spec_dir, 'scripts')
+    assert path.isdir(scripts_dir)
+    launcher_file = path.join(spec_dir, 'scripts', 'launch_docker.py')
+    assert path.isfile(launcher_file)
+
+    spec_utils.delete_staging_directory(staging_dir)
+    assert not path.exists(launcher_file)
+    assert not path.exists(scripts_dir)
+    assert not path.exists(spec_dir)


### PR DESCRIPTION
Add launcher files for kernel languages, docker and kubernetes.
Add logic to build toree-launcher and curl toree kernel jar.
Add spec_utils which will be called by "leaf providers" to copy the
appropriate launcher files to the staging directory.
Add tests for spec utils.
Activated tests on travis; provider tests are conditionally skipped
for now.