### PR TITLE
Add ability for providers to override find_kernels()

### DIFF
--- a/remote_kernel_provider/provider.py
+++ b/remote_kernel_provider/provider.py
@@ -15,6 +15,13 @@ class RemoteKernelProviderBase(KernelSpecProvider):
     kernel_file = None
     lifecycle_manager_classes = []
 
+    def find_kernels(self):
+        """Offers kernel types from installed kernelspec directories.
+
+           Subclasses can perform optional pre and post checks surrounding call to superclass.
+        """
+        return super(RemoteKernelProviderBase, self).find_kernels()
+
     def launch(self, kernelspec_name, cwd=None, kernel_params=None):
         """Launch a kernel, return (connection_info, kernel_manager).
 


### PR DESCRIPTION
It would be useful to allow providers to perform pre/post ops
for find_kernels(). For example, the KubernetesKernelProvider
will (quietly, via logging) enforce that it be run from within
a Kubernetes cluster and will not make k8s kernels available
until then.  These changes enable that behavior.